### PR TITLE
ci: add AgentGate PR guardrails

### DIFF
--- a/.agentgate.yml
+++ b/.agentgate.yml
@@ -1,0 +1,7 @@
+# AgentGate config — https://github.com/brett-buskirk/agent-gate
+version: 1
+rules:
+  # Solo-dev repo: surface out-of-scope / CI / lockfile edits as a warning
+  # rather than a hard block. secrets + dangerous_patterns stay at error.
+  scope:
+    severity: warning

--- a/.github/workflows/agentgate.yml
+++ b/.github/workflows/agentgate.yml
@@ -1,0 +1,17 @@
+name: AgentGate
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  statuses: write
+
+jobs:
+  agentgate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: brett-buskirk/agent-gate@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Wires in [AgentGate](https://github.com/brett-buskirk/agent-gate) to guard future PRs on this repo.

**What this adds**
- `.github/workflows/agentgate.yml` — runs AgentGate on every pull request (least-privilege write permissions so it can post its check + comment)
- `.agentgate.yml` — `secrets` and `dangerous_patterns` stay hard errors; `scope` is advisory (warning) for this solo-dev repo

AgentGate runs on this PR and passes green with one advisory **scope warning** for the new workflow file (a denied path by default — expected and non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
