### PR TITLE
docs: backfill the document suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to sudoku-solver are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-06-17
+
+First tagged release of the Sudoku Solver.
+
+### Added
+
+- Backtracking solver that solves any valid puzzle, including the hardest ones.
+- 100 built-in puzzles grouped by difficulty (Easy, Moderate, Difficult, Epic),
+  plus an empty board for entering your own.
+- Input validation with clear messages for invalid puzzles (a repeated digit)
+  and puzzles that have no solution.
+- Distinct colouring for given clues versus computed answers.
+- Keyboard arrow-key navigation between cells and a Clear button that resets the
+  current puzzle to its starting position.
+- Installable Progressive Web App (manifest + service worker) that works fully
+  offline.
+- SVG favicon and app icons.
+- MIT license.
+
+[Unreleased]: https://github.com/brett-buskirk/sudoku-solver/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/brett-buskirk/sudoku-solver/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+
+- **No direct commits to `main`** — branch → PR (`gh pr create`) → green checks → merge.
+- **AgentGate runs on every PR** — `secrets` + `dangerous_patterns` block; `scope` is advisory.
+- **Commits are signed & Verified**; never commit secrets (`.env`, keys are gitignored).
+- Branch naming: `feat/…`, `fix/…`, `docs/…`, `chore/…`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,22 @@
+# Roadmap
+
+Sudoku Solver is a small, finished browser app (plain HTML/CSS/JavaScript, no
+build step). It reached `v1.0.0` and does what it set out to do: reliably solve
+any valid puzzle, offline-capable as a PWA. It is in **maintenance mode** — no
+large feature push is planned.
+
+## Maintenance
+
+- Keep the app working on current browsers.
+- Fix any solver or validation bugs that surface.
+- Refresh the service worker cache version when files change so offline installs
+  update cleanly.
+
+## Nice-to-haves
+
+Genuine, optional improvements — none blocking, none scheduled:
+
+- [ ] Add a "generate a random puzzle" option so users aren't limited to the
+      built-in set.
+- [ ] Show a step-by-step solve (highlight cells as they are filled) instead of
+      revealing the finished grid all at once.


### PR DESCRIPTION
Adds the missing required docs for this repo: **CHANGELOG.md**, **CONTRIBUTING.md**, and **ROADMAP.md**. (README and LICENSE already exist.)

The CHANGELOG records the real `v1.0.0` release; the ROADMAP is honest about this being a finished, small utility in maintenance mode with a couple of genuine nice-to-haves.